### PR TITLE
Fix décalage des dates d’un jour lors de l’import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -475,7 +475,28 @@ function extractCreators(element) {
  */
 function extractWatchedDate(element) {
     try {
-        return element.otherUserInfos.dateDone.substring(0, 10);
+        // SensCritique stores watched dates as UTC timestamps.
+        // Letterboxd uses local YYYY-MM-DD format.
+        // Convert to local time to avoid off-by-one-day errors.
+        const utcDate = new Date(element.otherUserInfos.dateDone);
+
+        const options = {
+            timeZone: 'Europe/Paris',
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit'
+        };
+
+        const formatter = new Intl.DateTimeFormat('fr-FR', options);
+        const parts = formatter.formatToParts(utcDate);
+
+        const year = parts.find(p => p.type === 'year').value;
+        const month = parts.find(p => p.type === 'month').value;
+        const day = parts.find(p => p.type === 'day').value;
+
+        const localDate = `${year}-${month}-${day}`;
+
+        return localDate;
     } catch (e) {
         return "";
     }


### PR DESCRIPTION
Cette PR fix le bug reporté sur https://github.com/phileastv/SensBoxd/issues/3

Les dates sont stockées en UTC sur SensCritique. Example, un film visionné le 20 mars sera stocké comme `2025-03-19T23:00:00.000Z` soit une différence -1h en heure d’hiver. La date doit d’abord être convertie à l’heure locale.

Cela est précisé sur le [guide d’import de Letterbox](https://letterboxd.com/about/importing-data/) :

> If your data contains timestamps, please truncate these to calendar date only (after performing any necessary time-zone conversion, such as from UTC to your local time zone).

L’utilisation de Intl.DateTimeFormat fait que la bonne conversion sera effectuée aussi pendant les changement d’heure (heure d’été où c’est à UTC + 2).


**Note**

J’ai arbitrairement mis Europe/Paris en timezone, je ne sais pas si SensCritique store des dates à partir d’autres timezones. Il faudrait vérifier si cela pose problème pour les utilisateurices en DROM-COM.