### PR TITLE
Fix date de visionnage en cas de date manquante

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -475,6 +475,10 @@ function extractCreators(element) {
  */
 function extractWatchedDate(element) {
     try {
+        if (!element.otherUserInfos.dateDone) {
+            return "";
+        }
+
         // SensCritique stores watched dates as UTC timestamps.
         // Letterboxd uses local YYYY-MM-DD format.
         // Convert to local time to avoid off-by-one-day errors.


### PR DESCRIPTION
Oups mon précédent fix https://github.com/phileastv/SensBoxd/pull/7 a rendu les dates de visionnage manquantes mal gérées, en affichant `1970-01-01` au lieu de `''` 🙈

Cette PR fixe ça.

| Avant | Après |
|--------|--------|
|  <img width="200" alt="CleanShot 2025-09-13 at 08 02 47@2x" src="https://github.com/user-attachments/assets/e6b1cad0-9115-428d-846c-dd784e6a1619" /> | <img width="180"  alt="CleanShot 2025-09-13 at 08 03 09@2x" src="https://github.com/user-attachments/assets/c1f0ef88-e739-4fe1-b4bc-d23be81d1326" /> | 